### PR TITLE
[IMP] XML and language file improvments

### DIFF
--- a/hibp.xml
+++ b/hibp.xml
@@ -8,6 +8,7 @@
 	<authorUrl>http://simonchampion.net/</authorUrl>
 	<version>1.0.1</version>
 	<description>PLG_USER_HIBP_XML_DESCRIPTION</description>
+	<scriptfile>script.php</scriptfile>
 	<files>
 		<folder>language</folder>
 		<filename plugin="hibp">hibp.php</filename>

--- a/hibp.xml
+++ b/hibp.xml
@@ -1,26 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="3.8" type="plugin" group="user" client="site" order="100" method="upgrade">
+<extension version="3.8" type="plugin" group="user" client="site" method="upgrade">
 	<name>User - HIBP</name>
 	<author>Simon Champion</author>
 	<copyright>Simon Champion</copyright>
 	<license>http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL</license>
 	<authorEmail>simon@simonchampion.net</authorEmail>
-	<authorUrl></authorUrl>
+	<authorUrl>http://simonchampion.net/</authorUrl>
 	<version>1.0.1</version>
-	<description>PLG_USER_HIBP_DESCRIPTION</description>
+	<description>PLG_USER_HIBP_XML_DESCRIPTION</description>
 	<files>
+		<folder>language</folder>
 		<filename plugin="hibp">hibp.php</filename>
-        <filename>index.html</filename>
 	</files>
-    <languages>
-        <language tag="en-GB">language/en-GB/en-GB.plg_user_hibp.ini</language>
-        <language tag="en-GB">language/en-GB/en-GB.plg_user_hibp.sys.ini</language>
-    </languages>
 	<config>
 		<fields name="params">
 			<fieldset name="basic">
-                <field name="max_pwnage"  type="number" default="0" min="0" max="10" label="PLG_USER_HIBP_MAX_PWNAGE_LABEL" description="PLG_USER_HIBP_MAX_PWNAGE_DESC" />
-            </fieldset>
+				<field
+					name="max_pwnage"
+					label="PLG_USER_HIBP_MAX_PWNAGE_LABEL"
+					description="PLG_USER_HIBP_MAX_PWNAGE_DESC"
+					type="number"
+					default="0"
+					min="0"
+					max="10"
+				/>
+			</fieldset>
 		</fields>
 	</config>
 	<updateservers>

--- a/hibp.xml
+++ b/hibp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension version="3.8" type="plugin" group="user" client="site" method="upgrade">
-	<name>User - HIBP</name>
+	<name>plg_user_hibp</name>
 	<author>Simon Champion</author>
 	<copyright>Simon Champion</copyright>
 	<license>http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL</license>

--- a/language/en-GB/en-GB.plg_user_hibp.ini
+++ b/language/en-GB/en-GB.plg_user_hibp.ini
@@ -7,5 +7,5 @@
 ; These translations relate to strings that are used within the extension code itself.
 ; Note that plugins must specify `protected $autoloadLanguage = true; in order for these strings to be loaded.
 
-PLG_USER_RESTRICTUSERNAME_NAME="User - HIBP"
+PLG_USER_HIBP="User - HIBP"
 PLG_USER_HIBP_PASSWORD_KNOWN_TO_BE_COMPROMISED="Sorry, your chosen password is insecure, as it is known to have been previously compromised. This has been verified using the <a href='https://haveibeenpwned.com'>HaveIBeenPwned.com</a> API. For more information on this, please visit <a href='https://haveibeenpwned.com'>HaveIBeenPwned.com</a>. In the meanwhile, please select another password."

--- a/language/en-GB/en-GB.plg_user_hibp.ini
+++ b/language/en-GB/en-GB.plg_user_hibp.ini
@@ -1,4 +1,4 @@
-; @package   NotifyActivation
+; @package   HIBP
 ; @language  English
 ; @version   1.0.0
 ; @author    Simon Champion
@@ -8,5 +8,4 @@
 ; Note that plugins must specify `protected $autoloadLanguage = true; in order for these strings to be loaded.
 
 PLG_USER_RESTRICTUSERNAME_NAME="User - HIBP"
-
-PLG_USER_HIBP_PASSWORD_KNOWN_TO_BE_COMPROMISED="Sorry, your chosen password is insecure, as it is known to have been previously compromised. This has been verified using the <a href='http://haveibeenpwned.com'>HaveIBeenPwned.com</a> API. For more information on this, please visit <a href='http://haveibeenpwned.com'>HaveIBeenPwned.com</a>. In the meanwhile, please select another password."
+PLG_USER_HIBP_PASSWORD_KNOWN_TO_BE_COMPROMISED="Sorry, your chosen password is insecure, as it is known to have been previously compromised. This has been verified using the <a href='https://haveibeenpwned.com'>HaveIBeenPwned.com</a> API. For more information on this, please visit <a href='https://haveibeenpwned.com'>HaveIBeenPwned.com</a>. In the meanwhile, please select another password."

--- a/language/en-GB/en-GB.plg_user_hibp.sys.ini
+++ b/language/en-GB/en-GB.plg_user_hibp.sys.ini
@@ -7,8 +7,7 @@
 ; The sys translation strings are used within the admin panel, and relate to the plugin name itself and to the fieldnames in its config form.
 
 PLG_USER_HIBP_NAME="User - HIBP"
-PLG_USER_HIBP_DESCRIPTION="Verifies a user's password is secure, using the HaveIBeenPwned (HIBP) API"
 PLG_USER_HIBP="User - HIBP"
-
 PLG_USER_HIBP_MAX_PWNAGE_DESC="Maximum number of times a password can have been compromised before we block it. (ideally zero, but set to a low number if you really must, up to ten max)"
 PLG_USER_HIBP_MAX_PWNAGE_LABEL="Max Compromises"
+PLG_USER_HIBP_XML_DESCRIPTION="Verifies a user's password is secure, using the HaveIBeenPwned (HIBP) API"

--- a/language/en-GB/en-GB.plg_user_hibp.sys.ini
+++ b/language/en-GB/en-GB.plg_user_hibp.sys.ini
@@ -6,7 +6,6 @@
 ;
 ; The sys translation strings are used within the admin panel, and relate to the plugin name itself and to the fieldnames in its config form.
 
-PLG_USER_HIBP_NAME="User - HIBP"
 PLG_USER_HIBP="User - HIBP"
 PLG_USER_HIBP_MAX_PWNAGE_DESC="Maximum number of times a password can have been compromised before we block it. (ideally zero, but set to a low number if you really must, up to ten max)"
 PLG_USER_HIBP_MAX_PWNAGE_LABEL="Max Compromises"

--- a/script.php
+++ b/script.php
@@ -1,0 +1,52 @@
+<?php
+/**
+* @version   1.0.2
+* @package   plg_user_hibp
+* @author    Simon Champion
+* @copyright Simon Champion
+* @license   http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL
+*/
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Installer\InstallerScript;
+
+/**
+ * Installation class to perform additional changes during install/uninstall/update
+ *
+ * @since  1.0.2
+ */
+class plgUserHibpInstallerScript extends InstallerScript
+{
+	/**
+	 * Extension script constructor.
+	 *
+	 * @since   1.0.2
+	 */
+	public function __construct()
+	{
+		// Define the minumum versions to be supported.
+		$this->minimumJoomla = '3.8';
+		$this->minimumPhp    = '5.6';
+		
+		$this->deleteFiles = array(
+			'/administrator/language/en-GB/en-GB.plg_user_hibp.ini',
+			'/administrator/language/en-GB/en-GB.plg_user_hibp.sys.ini',
+		);
+	}
+
+	/**
+	 * Function to perform changes during postflight
+	 *
+	 * @param   string            $type    The action being performed
+	 * @param   ComponentAdapter  $parent  The class calling this method
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0.2
+	 */
+	public function postflight($type, $parent)
+	{
+		$this->removeFiles();
+	}
+}


### PR DESCRIPTION
Dear @Spudley with this PR I suggest some XML and language file improvments.

This includes:
- removal of unused language strings
- cleanup the main xml file
- remove the index.html (as they are not an requirement any more)
- change the language import to be local in the plugin
- add an script.php to enforce the joomla and php requirements on install and update as well as delete the outdated language files
- rename the XML Description language string from `PLG_USER_HIBP_DESCRIPTION` to `PLG_USER_HIBP_XML_DESCRIPTION`